### PR TITLE
Extend `storeFocus` to accept custom element

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 var storedFocusElement;
 
-exports.storeFocus = function() {
-  storedFocusElement = document.activeElement;
+exports.storeFocus = function(element) {
+  storedFocusElement = element || document.activeElement;
 };
 
 exports.clearStoredFocus = function() {

--- a/test.js
+++ b/test.js
@@ -7,13 +7,16 @@ describe('focusStore', function() {
   beforeEach(function() {
     this.button1 = document.createElement('button');
     this.button2 = document.createElement('button');
+    this.button3 = document.createElement('button');
     document.body.appendChild(this.button1);
     document.body.appendChild(this.button2);
+    document.body.appendChild(this.button3);
   });
 
   afterEach(function() {
     this.button1.remove();
     this.button2.remove();
+    this.button3.remove();
   });
 
   it('should store and restore focus', function() {
@@ -40,5 +43,13 @@ describe('focusStore', function() {
     expect(function() {
       focusStore.restoreFocus();
     }).not.to.throw();
+  });
+
+  it('should accept a custom element to focus', function() {
+    this.button1.focus();
+    focusStore.storeFocus(this.button3);
+    this.button2.focus();
+    focusStore.restoreFocus();
+    expect(document.activeElement).to.equal(this.button3);
   });
 });


### PR DESCRIPTION
I have a usecase where it's useful to store focus to a custom element, so I have extended `storeFocus` to accept an argument which will be stored instead of `document.activeElement` if provided.